### PR TITLE
[makeotfParts] decode glyphName to (unicode) str

### DIFF
--- a/Lib/ufo2fdk/makeotfParts.py
+++ b/Lib/ufo2fdk/makeotfParts.py
@@ -571,11 +571,9 @@ def normalizeGlyphName(glyphName, uniValue, existing):
     >>> normalizeGlyphName("a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-0-1-2-3-4-5", None, [])
     'glyph1'
     """
-    # convert to unicode
-    glyphName = str(glyphName)
     # remove illegal characters
     glyphName = unicodedata.normalize("NFKD", glyphName)
-    glyphName = glyphName.encode("ascii", "ignore")
+    glyphName = glyphName.encode("ascii", "ignore").decode("ascii")
     glyphName = "".join([c for c in glyphName if c in _validCharacters])
     # no new name
     if not glyphName:


### PR DESCRIPTION
`glyphName` is first encoded to bytes, and then each character tested to see
if they are in the set of `_validCharacters`. However, the latter is made of
`str` instances. This means `c in _validCharacters` is always returning False,
and the resulting glyphName is left as an empty string.
This in turn makes `isLegalGlyphName` function fail with IndexError:

```
Traceback (most recent call last):
  File "ufo2fdk/Lib/ufo2fdk/makeotfParts.py", line 545, in isLegalGlyphName
    if glyphName[0] in _digits:
```