### PR TITLE
[kernFeatureWriter] fix `makeLegalClassName` not returning a unique class name

### DIFF
--- a/Lib/ufo2fdk/kernFeatureWriter.py
+++ b/Lib/ufo2fdk/kernFeatureWriter.py
@@ -140,7 +140,7 @@ class KernFeatureWriter(object):
         for groupNames, feaPrefix in ((list(self.side1Groups.keys()), side1FeaPrefix), (list(self.side2Groups.keys()), side2FeaPrefix)):
             for groupName in sorted(groupNames):
                 className = feaPrefix + groupName[groupPrefixLength:]
-                mapping[groupName] = makeLegalClassName(className, list(mapping.keys()))
+                mapping[groupName] = makeLegalClassName(className, mapping.values())
         # kerning
         newPairs = {}
         for (side1, side2), value in list(self.pairs.items()):
@@ -359,6 +359,15 @@ def makeLegalClassName(name, existing):
     '@kern1.noTransPossible'
     >>> makeLegalClassName(u"@kern1.•", [])
     '@kern1.noTransPossible'
+
+    clashing
+    --------
+
+    >>> makeLegalClassName("@kern2.@MMK_R_PUNCT_questiondown_2ND", [])
+    '@kern2.MMK_R_PUNCT_questiondown'
+
+    >>> makeLegalClassName("@kern2.@MMK_R_PUNCT_questiondown.case_2ND", ["@kern2.MMK_R_PUNCT_questiondown"])
+    '@kern2.MMK_R_PUNCT_questiondow1'
     """
     # slice off the prefix
     prefix = str(name[:classPrefixLength])
@@ -374,7 +383,7 @@ def makeLegalClassName(name, existing):
     # add the prefix
     name = prefix + name
     # make sure it is unique
-    _makeUniqueClassName(name, existing)
+    name = _makeUniqueClassName(name, existing)
     return name
 
 def _makeUniqueClassName(name, existing, counter=0):

--- a/Lib/ufo2fdk/kernFeatureWriter.py
+++ b/Lib/ufo2fdk/kernFeatureWriter.py
@@ -414,7 +414,7 @@ def _test():
     >>> from defcon import Font
     >>> font = Font()
     >>> for glyphName in AGL2UV:
-    ...     font.newGlyph(glyphName)
+    ...     g = font.newGlyph(glyphName)
     >>> kerning = {
     ...     # various pair types
     ...     ("Agrave", "Agrave") : -100,


### PR DESCRIPTION
There are two issues here.
    
One is that `makeLegalClassName` is getting `mapping.keys()` containing a list of existing _group_ names, whereas it should get the `mapping.values()` instead (i.e. the list of existing _class_ names), and pass that list to `_makeUniqueClassName` function where the name clashes are detected.
    
The second, even worse, issue is that the returned value from `_makeUniqueClassName` is not even stored anywhere, but is thrown away by the calling function.
    
The issue was introduced for the first time in 2012 with commit ce2d685d3c63af0ef6fc0d623da067de0d7a9392 on ufo2fdk's ufo3 branch.
    
I wonder how many fonts out there have broken GPOS kern features because of this...
